### PR TITLE
Migrate from roo to creek

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,30 @@
 PATH
   remote: .
   specs:
-    simple_text_extract (1.3.0)
-      roo (~> 2.9.0)
+    simple_text_extract (2.0.0)
+      creek (~> 2.5.3)
       rubyzip (~> 2.3.2)
       spreadsheet (~> 1.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.3)
+    creek (2.5.3)
+      nokogiri (>= 1.10.0)
+      rubyzip (>= 1.0.0)
+    method_source (1.0.0)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
     mocha (1.13.0)
-    nokogiri (1.13.3)
+    nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.6.0)
     rake (13.0.6)
-    roo (2.9.0)
-      nokogiri (~> 1)
-      rubyzip (>= 1.3.0, < 3.0.0)
     ruby-ole (1.2.12.2)
     rubyzip (2.3.2)
     spreadsheet (1.3.0)
@@ -31,6 +36,7 @@ PLATFORMS
 DEPENDENCIES
   minitest (~> 5.0)
   mocha
+  pry
   rake (~> 13.0)
   simple_text_extract!
 

--- a/lib/simple_text_extract/format_extractor/xls_x.rb
+++ b/lib/simple_text_extract/format_extractor/xls_x.rb
@@ -4,15 +4,15 @@ module SimpleTextExtract
   module FormatExtractor
     class XlsX < Base
       def extract
-        require "roo"
-
-        spreadsheet = Roo::Spreadsheet.open(file, only_visible_sheets: true)
-
+        require 'creek'
+        creek = Creek::Book.new(file)
         text = []
 
-        spreadsheet.each_with_pagename do |name, sheet|
-          text << name
-          1.upto(sheet.last_row.to_i) { |row| text << sheet.row(row) }
+        creek.sheets.each do |sheet|
+          next if sheet.state == 'hidden'
+
+          text << sheet.name
+          sheet.rows.each { |row| text << row.values }
         end
 
         text.flatten.join(" ")

--- a/simple_text_extract.gemspec
+++ b/simple_text_extract.gemspec
@@ -28,11 +28,12 @@ Gem::Specification.new do |spec|
   spec.requirements << "pdftotext/poppler"
   spec.required_ruby_version = ">= 2.5"
 
-  spec.add_runtime_dependency "roo", "~> 2.9.0"
+  spec.add_runtime_dependency "creek", "~> 2.5.3"
   spec.add_runtime_dependency "spreadsheet", "~> 1.3.0"
   spec.add_runtime_dependency "rubyzip", "~> 2.3.2"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "mocha"
+  spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
Open large xlsx files with `roo` hangs.
Moving from `roo` to [creek](https://github.com/pythonicrubyist/creek) has improved memory usage.
All tests passed.

https://github.com/roo-rb/roo/issues/179