### PR TITLE
allow minor dependency upgrades, add ruby 3.4 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - ruby: 3.4
+            gemfile: Gemfile
           - ruby: 3.3
             gemfile: Gemfile
           - ruby: 3.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,9 +4,9 @@ PATH
     simple_text_extract (3.0.9)
       base64
       csv
-      roo (~> 2.10.0)
-      rubyzip (~> 2.3.2)
-      spreadsheet (~> 1.3.0)
+      roo (~> 2.10)
+      rubyzip (~> 2.3)
+      spreadsheet (~> 1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -56,7 +56,7 @@ GEM
     ruby-ole (1.2.13.1)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.2)
+    rubyzip (2.4.1)
     spreadsheet (1.3.3)
       bigdecimal
       ruby-ole

--- a/simple_text_extract.gemspec
+++ b/simple_text_extract.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec|
   spec.requirements << "antiword"
   spec.requirements << "pdftotext/poppler"
 
-  spec.add_dependency "roo", "~> 2.10.0"
-  spec.add_dependency "rubyzip", "~> 2.3.2"
-  spec.add_dependency "spreadsheet", "~> 1.3.0"
+  spec.add_dependency "roo", "~> 2.10"
+  spec.add_dependency "rubyzip", "~> 2.3"
+  spec.add_dependency "spreadsheet", "~> 1.3"
   spec.add_dependency "base64"
   spec.add_dependency "csv"
 end


### PR DESCRIPTION
# Description
This adds ruby 3.4 to the CI test matrix and loosens the dependency version requirements to allow for minor version upgrades for roo, rubyzip and spreadsheet. 